### PR TITLE
Add cloudtruth_metadata attribute to kubernetes resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.yardoc
 /_yardoc/
 /coverage/
+/local/
 /doc/
 /pkg/
 /spec/reports/

--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ ones:
  * dns_safe - ensures the string is safe for use as a kubernetes resource name (i.e. Namespace/ConfigMap/Secret names)
  * env_safe - ensures the string is safe for setting as a shell environment variable
 
+By default, kubetruth will add the `cloudtruth_metadata` key to each ConfigMap
+and Secret under management.  This can be disabled with the `noMetadata` helm
+setting at install time.  The data contained by this key helps to illustrate how
+project inclusion affects the project the resources were written for.   It
+currently shows the project heirarchy and the project each parameter originates
+from, for example an entry like `timeout: myService (commonService -> common)`
+indicates that the timeout parameter is getting its value from the `myService`
+project, and if you removed it from there, it would then get it from the
+`commonService` project, and if you removed that, it would then get it from the
+`common` project.
+
 ### Example Config
 
 The `projectmapping` resource has a shortname of `pm` for convenience when using kubectl.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Parameterize the helm install with `--set appSettings.**` to control how kubetru
 | appSettings.apiKey | The cloudtruth api key.  Read only access is sufficient | string | n/a | yes |
 | appSettings.environment | The cloudtruth environment to lookup parameter values for.  Use a separate helm install for each environment | string | `default` | yes |
 | appSettings.pollingInterval | Interval to poll cloudtruth api for changes | integer | 300 | no |
-| appSettings.debug | Debug logging | flag | n/a | no |
+| appSettings.noMetadata | Do not write cloudtruth metadata (e.g. param value origins) to kubernetes resources | flag | false | no |
+| appSettings.debug | Debug logging | flag | false | no |
 | projectMappings.root.project_selector | A regexp to limit the projects acted against (client-side).  Supplies any named matches for template evaluation | string | "" | no |
 | projectMappings.root.key_selector | A regexp to limit the keys acted against (client-side).  Supplies any named matches for template evaluation | string | "" | no |
 | projectMappings.root.key_filter | Limits the keys fetched to contain the given substring (server-side, api search param) | string | "" | no |

--- a/helm/kubetruth/templates/deployment.yaml
+++ b/helm/kubetruth/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
             - --polling-interval
             - "{{ .Values.appSettings.pollingInterval }}"
             {{- end }}
+            {{- if .Values.appSettings.noMetadata }}
+            - --no-metadata
+            {{- end }}
             {{- if .Values.appSettings.debug }}
             - --debug
             {{- end }}

--- a/helm/kubetruth/values.yaml
+++ b/helm/kubetruth/values.yaml
@@ -69,9 +69,9 @@ affinity: {}
 appSettings:
   apiKey:
   environment:
+  noMetadata: false
   pollingInterval:
   debug: false
-  config:
 
 # Create instances of the ProjectMapping CRD.  A single mapping with scope=root
 # is required (named root below).  You can also add multiple override mappings

--- a/lib/kubetruth/cli.rb
+++ b/lib/kubetruth/cli.rb
@@ -42,16 +42,20 @@ module Kubetruth
       Integer(a)
     end
 
+    option "--[no-]metadata",
+           :flag, "Saves additional cloudtruth metadata in the kubernetes resources, e.g. the project origin for param values after inclusions/overrides are applied",
+           default: true
+
     option ["-n", "--dry-run"],
-           :flag, "perform a dry run",
+           :flag, "Perform a dry run",
            default: false
 
     option ["-q", "--quiet"],
-           :flag, "suppress output",
+           :flag, "Suppress output",
            default: false
 
     option ["-d", "--debug"],
-           :flag, "debug output",
+           :flag, "Debug output",
            default: false
 
     option ["-c", "--[no-]color"],
@@ -92,7 +96,7 @@ module Kubetruth
           api_url: kube_url
       }
 
-      etl = ETL.new(ct_context: ct_context, kube_context: kube_context, dry_run: dry_run?)
+      etl = ETL.new(ct_context: ct_context, kube_context: kube_context, dry_run: dry_run?, metadata: metadata?)
 
       etl.with_polling(polling_interval) do
         etl.apply

--- a/lib/kubetruth/etl.rb
+++ b/lib/kubetruth/etl.rb
@@ -137,6 +137,10 @@ module Kubetruth
         # TODO: make project inclusion recursive?
         included_params = []
         project_spec.included_projects.each do |included_project|
+          if included_project == project
+            logger.warn("Skipping project's import of itself, included_projects for '#{project}' are: #{project_spec.included_projects.inspect}")
+            next
+          end
           included_data = project_data[included_project]
           if included_data.nil?
             logger.warn "Skipping the included project not selected by root selector: #{included_project}"

--- a/lib/kubetruth/etl.rb
+++ b/lib/kubetruth/etl.rb
@@ -9,10 +9,11 @@ module Kubetruth
   class ETL
     include GemLogger::LoggerSupport
 
-    def initialize(ct_context:, kube_context:, dry_run: false)
+    def initialize(ct_context:, kube_context:, dry_run: false, metadata: true)
       @ct_context = ct_context
       @kube_context = kube_context
       @dry_run = dry_run
+      @metadata = metadata
       @kubeapis = {}
     end
 
@@ -131,6 +132,8 @@ module Kubetruth
           next
         end
 
+        param_origins = {}
+
         # TODO: make project inclusion recursive?
         included_params = []
         project_spec.included_projects.each do |included_project|
@@ -139,7 +142,16 @@ module Kubetruth
             logger.warn "Skipping the included project not selected by root selector: #{included_project}"
             next
           end
+
+          included_data[:params].each do |p|
+            param_origins[p.key] = included_project
+          end
+
           included_params.concat(included_data[:params])
+        end
+
+        data[:params].each do |p|
+          param_origins[p.key] = project
         end
 
         # constructing the hash will cause any overrides to happen in the right
@@ -149,6 +161,12 @@ module Kubetruth
         config_params, secret_params = (parts[false] || []), (parts[true] || [])
         config_param_hash = params_to_hash(config_params)
         secret_param_hash = params_to_hash(secret_params)
+
+        if @metadata
+          param_source_parts = param_origins.group_by {|k, v| config_param_hash.has_key?(k) }
+          config_param_hash[:cloudtruth_metadata] = {param_origins: Hash[param_source_parts[true] || []]}.to_json
+          secret_param_hash[:cloudtruth_metadata] = {param_origins: Hash[param_source_parts[false] || []]}.to_json
+        end
 
         apply_config_map(namespace: data[:namespace], name: data[:configmap_name], param_hash: config_param_hash)
 

--- a/lib/kubetruth/etl.rb
+++ b/lib/kubetruth/etl.rb
@@ -144,14 +144,16 @@ module Kubetruth
           end
 
           included_data[:params].each do |p|
-            param_origins[p.key] = included_project
+            param_origins[p.key] ||= []
+            param_origins[p.key] << included_project
           end
 
           included_params.concat(included_data[:params])
         end
 
         data[:params].each do |p|
-          param_origins[p.key] = project
+          param_origins[p.key] ||= []
+          param_origins[p.key] << project
         end
 
         # constructing the hash will cause any overrides to happen in the right
@@ -163,9 +165,23 @@ module Kubetruth
         secret_param_hash = params_to_hash(secret_params)
 
         if @metadata
-          param_source_parts = param_origins.group_by {|k, v| config_param_hash.has_key?(k) }
-          config_param_hash[:cloudtruth_metadata] = {param_origins: Hash[param_source_parts[true] || []]}.to_json
-          secret_param_hash[:cloudtruth_metadata] = {param_origins: Hash[param_source_parts[false] || []]}.to_json
+          metadata = {}
+          metadata["project_heirarchy"] = (project_spec.included_projects + [project]).reverse.join(" -> ")
+
+          param_origins.merge!(param_origins) do |_, v|
+            origin = "#{v.pop}"
+            if v.length > 0
+              origin << " (#{v.reverse.join(" -> ")})"
+            end
+            origin
+          end
+
+          param_origins_parts = param_origins.group_by {|k, v| config_param_hash.has_key?(k) }
+          config_origins = Hash[param_origins_parts[true] || []]
+          secret_origins = Hash[param_origins_parts[false] || []]
+
+          config_param_hash[:cloudtruth_metadata] = metadata.merge({ "parameter_origins" => config_origins }).to_yaml
+          secret_param_hash[:cloudtruth_metadata] = metadata.merge({ "parameter_origins" => secret_origins }).to_yaml
         end
 
         apply_config_map(namespace: data[:namespace], name: data[:configmap_name], param_hash: config_param_hash)

--- a/spec/kubetruth/cli_spec.rb
+++ b/spec/kubetruth/cli_spec.rb
@@ -95,6 +95,7 @@ module Kubetruth
             --kube-url ku
             --dry-run
             --polling-interval 27
+            --no-metadata
         ]
         etl = double(ETL)
         expect(ETL).to receive(:new).with(ct_context: {
@@ -107,7 +108,8 @@ module Kubetruth
                                               token: "kt",
                                               api_url: "ku"
                                           },
-                                          dry_run: true).and_return(etl)
+                                          dry_run: true,
+                                          metadata: false).and_return(etl)
         expect(etl).to receive(:with_polling).with(27)
         cli.run(args)
       end

--- a/spec/kubetruth/etl_spec.rb
+++ b/spec/kubetruth/etl_spec.rb
@@ -521,6 +521,26 @@ module Kubetruth
         etl.apply()
       end
 
+      it "skips project include of self" do
+        base_params = [
+          Parameter.new(key: "param0", value: "value0", secret: false),
+        ]
+
+        expect(etl).to receive(:load_config).and_return(Kubetruth::Config.new([
+                                                                                {
+                                                                                  scope: "root",
+                                                                                  included_projects: ["base"]
+                                                                                }
+                                                                              ]))
+
+        expect(etl.ctapi).to receive(:project_names).and_return(["base"])
+        expect(etl).to receive(:get_params).with("base", any_args).and_return(base_params)
+        expect(etl).to receive(:apply_config_map)
+        allow(etl).to receive(:apply_secret)
+        etl.apply()
+        expect(Logging.contents).to include("Skipping project's import of itself")
+      end
+
       it "indicates param's project origin in metadata" do
         base_params = [
           Parameter.new(key: "param0", value: "value0", secret: false),


### PR DESCRIPTION
Used to show which project a param is getting its value from due to project inclusion/overrides.

This is what it looks like in kubernetes dashboard.  The `service-demo1` project includes the `common` project to get the `aws_region`, `domain`, `environment` and `timeout` params, the `common-service` project to get `timeout` and `rate_limit` and  overrides `aws_region` and `timeout` only.
<br/>
![image](https://user-images.githubusercontent.com/3606/118504933-f2b51e00-b6f9-11eb-9cdd-829ca6864d24.png)
<br/>
![image](https://user-images.githubusercontent.com/3606/118505221-39a31380-b6fa-11eb-83b8-a666b4ec234b.png)
