### PR TITLE
Allow for secrets from outside the chart

### DIFF
--- a/helm/kubetruth/Chart.yaml
+++ b/helm/kubetruth/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.2.0
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/helm/kubetruth/templates/_helpers.tpl
+++ b/helm/kubetruth/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the secret name
+*/}}
+{{- define "kubetruth.secretName" -}}
+{{- if .Values.secret.create }}
+{{- default (include "kubetruth.fullname" .) .Values.secret.name }}
+{{- else }}
+{{- required "A secret name is required in .Values.secret.name when .Values.secret.create is false!" .Values.secret.name }}
+{{- end }}
+{{- end }}

--- a/helm/kubetruth/templates/deployment.yaml
+++ b/helm/kubetruth/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:
             - secretRef:
-                name: {{ include "kubetruth.fullname" . }}
+                name: {{ include "kubetruth.secretName" . }}
           args:
             - app
             {{- if .Values.appSettings.apiUrl }}

--- a/helm/kubetruth/templates/secret.yaml
+++ b/helm/kubetruth/templates/secret.yaml
@@ -1,9 +1,11 @@
+{{- if .Values.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "kubetruth.fullname" . }}
+  name: {{ include "kubetruth.secretName" . }}
   namespace:  {{ .Release.Namespace }}
   labels:
     {{- include "kubetruth.labels" . | nindent 4 }}
 data:
   CLOUDTRUTH_API_KEY: {{ required "The cloudtruth api key needs to be set in .Values.appSettings.apiKey!" .Values.appSettings.apiKey | b64enc | quote }}
+{{- end }}

--- a/helm/kubetruth/values.yaml
+++ b/helm/kubetruth/values.yaml
@@ -86,6 +86,13 @@ appSettings:
   pollingInterval:
   debug: false
 
+# If secret.create == false, secret generation is left to the user
+# outside of the chart, and a name should be specified
+# See templates/secret.yaml for expected values
+secret:
+  create: true
+  name: ""
+
 # Create instances of the ProjectMapping CRD.  A single mapping with scope=root
 # is required (named root below).  You can also add multiple override mappings
 # (scope=override).  Any properties not overriden are inherited from the root


### PR DESCRIPTION
The goal is to allow for consumers to set their own secret, given they use gitops workflows where charts are committed to git repos.  This avoids saving the API key (and other future sensitive information) in the gitops repo.